### PR TITLE
Replace ingestion blocking await with features::join

### DIFF
--- a/ingest/src/ingest.rs
+++ b/ingest/src/ingest.rs
@@ -56,20 +56,25 @@ impl Ingester {
 
         loop {
             if tip_block_num >= next_block {
-                let block: Block<Transaction> = self
+                let block = self
                     .client
-                    .send(GetBlockByNumber(next_block.into()).into())
-                    .await
-                    .context("get block data")?
-                    .try_into_single()
-                    .unwrap();
-                let receipts: Vec<TransactionReceipt> = self
+                    .send(GetBlockByNumber(next_block.into()).into());
+                    // .await
+                    // .context("get block data")?
+                    // .try_into_single()
+                    // .unwrap();
+                let receipts = self
                     .client
-                    .send(GetBlockReceipts(next_block.into()).into())
-                    .await
-                    .context("get block receipts")?
-                    .try_into_single()
-                    .unwrap();
+                    .send(GetBlockReceipts(next_block.into()).into());
+                    // .await
+                    // .context("get block receipts")?
+                    // .try_into_single()
+                    // .unwrap();
+
+                let (block, receipts) = futures::join!(block, receipts);
+
+                let block = block.context("get block data")?.try_into_single().unwrap();
+                let receipts = receipts.context("get block receipts")?.try_into_single().unwrap();
 
                 log::trace!("downloaded data for block {}", next_block);
 

--- a/ingest/src/ingest.rs
+++ b/ingest/src/ingest.rs
@@ -59,17 +59,10 @@ impl Ingester {
                 let block = self
                     .client
                     .send(GetBlockByNumber(next_block.into()).into());
-                    // .await
-                    // .context("get block data")?
-                    // .try_into_single()
-                    // .unwrap();
+                
                 let receipts = self
                     .client
                     .send(GetBlockReceipts(next_block.into()).into());
-                    // .await
-                    // .context("get block receipts")?
-                    // .try_into_single()
-                    // .unwrap();
 
                 let (block, receipts) = futures::join!(block, receipts);
 

--- a/ingest/src/ingest.rs
+++ b/ingest/src/ingest.rs
@@ -56,18 +56,17 @@ impl Ingester {
 
         loop {
             if tip_block_num >= next_block {
-                let block = self
-                    .client
-                    .send(GetBlockByNumber(next_block.into()).into());
-                
-                let receipts = self
-                    .client
-                    .send(GetBlockReceipts(next_block.into()).into());
+                let block = self.client.send(GetBlockByNumber(next_block.into()).into());
+
+                let receipts = self.client.send(GetBlockReceipts(next_block.into()).into());
 
                 let (block, receipts) = futures::join!(block, receipts);
 
                 let block = block.context("get block data")?.try_into_single().unwrap();
-                let receipts = receipts.context("get block receipts")?.try_into_single().unwrap();
+                let receipts = receipts
+                    .context("get block receipts")?
+                    .try_into_single()
+                    .unwrap();
 
                 log::trace!("downloaded data for block {}", next_block);
 


### PR DESCRIPTION
This PR should speed up block processing in general and especially in case of exponential backoff triggering

https://rust-lang.github.io/async-book/06_multiple_futures/02_join.html